### PR TITLE
Add option to restrict the particles the force applies to

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ torch.onnx.export(model=PeriodicForce(),
                   dynamic_axes={"positions":[0], "forces":[0]})
 ```
 
+## Applying to a Subset of Particles
+
+In some cases one wants to model part of a system with a machine learning potential and the rest with a
+conventional force field.  You can restrict which particles the `OnnxForce` acts on by calling `setParticleIndices()`.
+For example, the following applies it only to the first 50 particles in the system.
+
+```python
+particles = list(range(50))
+force.setParticleIndices(particles)
+```
+
+The `positions` tensor passed to the model will contain only the positions of the specified particles.
+Likewise, the `forces` tensor returned by the model should contain only the forces on those particles.
+
 ## Global Parameters
 
 An `OnnxForce` can define global parameters that the model depends on.  The model should have an additional

--- a/openmmapi/include/OnnxForce.h
+++ b/openmmapi/include/OnnxForce.h
@@ -102,6 +102,16 @@ public:
      */
     void setExecutionProvider(ExecutionProvider provider);
     /**
+     * Get the indices of the particles this force is applied to.  If this is empty, the
+     * force is applied to all particles in the system.
+     */
+    const std::vector<int>& getParticleIndices() const;
+    /**
+     * Set the indices of the particles this force is applied to.  If this is empty, the
+     * force is applied to all particles in the system.
+     */
+    void setParticleIndices(const std::vector<int>& indices);
+    /**
      * Get whether this force uses periodic boundary conditions.
      */
     bool usesPeriodicBoundaryConditions() const;
@@ -169,6 +179,7 @@ private:
     class GlobalParameterInfo;
     void initProperties(const std::map<std::string, std::string>& properties);
     std::vector<uint8_t> model;
+    std::vector<int> particleIndices;
     ExecutionProvider provider;
     bool periodic;
     std::vector<GlobalParameterInfo> globalParameters;

--- a/openmmapi/include/internal/OnnxForceImpl.h
+++ b/openmmapi/include/internal/OnnxForceImpl.h
@@ -60,6 +60,7 @@ private:
     Ort::Session session;
     std::vector<Ort::Value> inputTensors, outputTensors;
     std::vector<const char*> inputNames;
+    std::vector<int> particleIndices;
     std::vector<float> positionVec, paramVec;
     float boxVectors[9];
 };

--- a/openmmapi/src/OnnxForce.cpp
+++ b/openmmapi/src/OnnxForce.cpp
@@ -74,6 +74,14 @@ void OnnxForce::setExecutionProvider(OnnxForce::ExecutionProvider provider) {
     this->provider = provider;
 }
 
+const vector<int>& OnnxForce::getParticleIndices() const {
+    return particleIndices;
+}
+
+void OnnxForce::setParticleIndices(const vector<int>& indices) {
+    particleIndices = indices;
+}
+
 bool OnnxForce::usesPeriodicBoundaryConditions() const {
     return periodic;
 }

--- a/python/onnxplugin.i
+++ b/python/onnxplugin.i
@@ -34,6 +34,7 @@
 
 namespace std {
     %template(vectorbyte) vector<unsigned char>;
+    %template(vectorint) vector<int>;
     %template(property_map) map<std::string, std::string>;
 };
 
@@ -53,6 +54,8 @@ public:
     const std::vector<uint8_t>& getModel() const;
     ExecutionProvider getExecutionProvider() const;
     void setExecutionProvider(ExecutionProvider provider);
+    const std::vector<int>& getParticleIndices() const;
+    void setParticleIndices(const std::vector<int>& indices);
     bool usesPeriodicBoundaryConditions() const;
     void setUsesPeriodicBoundaryConditions(bool periodic);
     int getNumGlobalParameters() const;

--- a/serialization/tests/TestSerializeOnnxForce.cpp
+++ b/serialization/tests/TestSerializeOnnxForce.cpp
@@ -49,6 +49,7 @@ void testSerialization() {
     force.addGlobalParameter("y", 2.221);
     force.setUsesPeriodicBoundaryConditions(true);
     force.setProperty("UseGraphs", "true");
+    force.setParticleIndices({0, 2, 4});
 
     // Serialize and then deserialize it.
 
@@ -61,6 +62,7 @@ void testSerialization() {
     OnnxForce& force2 = *copy;
     ASSERT_EQUAL_CONTAINERS(force.getModel(), force2.getModel());
     ASSERT_EQUAL(force.getForceGroup(), force2.getForceGroup());
+    ASSERT_EQUAL_CONTAINERS(force.getParticleIndices(), force2.getParticleIndices());
     ASSERT_EQUAL(force.getNumGlobalParameters(), force2.getNumGlobalParameters());
     for (int i = 0; i < force.getNumGlobalParameters(); i++) {
         ASSERT_EQUAL(force.getGlobalParameterName(i), force2.getGlobalParameterName(i));


### PR DESCRIPTION
This adds a `setParticleIndices()` method to OnnxForce.  It allows you to easily use the ML potential for only part of the system.